### PR TITLE
Use https to maintain user privacy and fix broken link to googlecode.

### DIFF
--- a/SugarModules/modules/jjwg_Maps/javascript/markerclusterer.js
+++ b/SugarModules/modules/jjwg_Maps/javascript/markerclusterer.js
@@ -1611,8 +1611,9 @@ MarkerClusterer.BATCH_SIZE_IE = 500;
  * @type {string}
  * @constant
  */
-MarkerClusterer.IMAGE_PATH = "http://google-maps-utility-library-v3.googlecode.com/svn/trunk/markerclustererplus/images/m";
-
+// MarkerClusterer.IMAGE_PATH = "https://google-maps-utility-library-v3.googlecode.com/svn/trunk/markerclustererplus/images/m";
+// link to googlecode is dead.  the project has moved to github.
+MarkerClusterer.IMAGE_PATH = "https://raw.githubusercontent.com/googlemaps/js-marker-clusterer/gh-pages/images/m";
 
 /**
  * The default extension name for the marker cluster images.

--- a/SugarModules/modules/jjwg_Maps/tpls/AccountsInfoWindow.tpl
+++ b/SugarModules/modules/jjwg_Maps/tpls/AccountsInfoWindow.tpl
@@ -5,7 +5,7 @@ href="index.php?module={$module_type}&action=DetailView&record={$fields.id}">{$f
 <br />{$address}<br />
 <i>{$mod_strings.LBL_MAP_ASSIGNED_TO} {$fields.assigned_user_name}</i>
 <br /><br />
-<a target="_blank" href="http://maps.google.com/maps?q={$address|escape:'url'}">{$mod_strings.LBL_MAP_GOOGLE_MAPS_VIEW}</a>&nbsp;
-<a target="_blank" href="http://maps.google.com/maps?saddr={$current_user_address|escape:'url'}&daddr={$address|escape:'url'}">{$mod_strings.LBL_MAP_GET_DIRECTIONS}</a>
+<a target="_blank" href="https://maps.google.com/maps?q={$address|escape:'url'}">{$mod_strings.LBL_MAP_GOOGLE_MAPS_VIEW}</a>&nbsp;
+<a target="_blank" href="https://maps.google.com/maps?saddr={$current_user_address|escape:'url'}&daddr={$address|escape:'url'}">{$mod_strings.LBL_MAP_GET_DIRECTIONS}</a>
 </div>
 

--- a/SugarModules/modules/jjwg_Maps/tpls/CasesInfoWindow.tpl
+++ b/SugarModules/modules/jjwg_Maps/tpls/CasesInfoWindow.tpl
@@ -5,6 +5,6 @@ href="index.php?module={$module_type}&action=DetailView&record={$fields.id}">{$f
 <br />{$address}<br />
 <i>{$mod_strings.LBL_MAP_ASSIGNED_TO} {$fields.assigned_user_name}</i>
 <br /><br />
-<a target="_blank" href="http://maps.google.com/maps?q={$address|escape:'url'}">{$mod_strings.LBL_MAP_GOOGLE_MAPS_VIEW}</a>&nbsp;
-<a target="_blank" href="http://maps.google.com/maps?saddr={$current_user_address|escape:'url'}&daddr={$address|escape:'url'}">{$mod_strings.LBL_MAP_GET_DIRECTIONS}</a>
+<a target="_blank" href="https://maps.google.com/maps?q={$address|escape:'url'}">{$mod_strings.LBL_MAP_GOOGLE_MAPS_VIEW}</a>&nbsp;
+<a target="_blank" href="https://maps.google.com/maps?saddr={$current_user_address|escape:'url'}&daddr={$address|escape:'url'}">{$mod_strings.LBL_MAP_GET_DIRECTIONS}</a>
 </div>

--- a/SugarModules/modules/jjwg_Maps/tpls/ContactsInfoWindow.tpl
+++ b/SugarModules/modules/jjwg_Maps/tpls/ContactsInfoWindow.tpl
@@ -7,6 +7,6 @@ href="index.php?module=Accounts&action=DetailView&record={$fields.account_id}">{
 <br />{$address}
 <br /><i>{$mod_strings.LBL_MAP_ASSIGNED_TO} {$fields.assigned_user_name}</i>
 <br /><br />
-<a target="_blank" href="http://maps.google.com/maps?q={$address|escape:'url'}">{$mod_strings.LBL_MAP_GOOGLE_MAPS_VIEW}</a>&nbsp;
-<a target="_blank" href="http://maps.google.com/maps?saddr={$current_user_address|escape:'url'}&daddr={$address|escape:'url'}">{$mod_strings.LBL_MAP_GET_DIRECTIONS}</a>
+<a target="_blank" href="https://maps.google.com/maps?q={$address|escape:'url'}">{$mod_strings.LBL_MAP_GOOGLE_MAPS_VIEW}</a>&nbsp;
+<a target="_blank" href="https://maps.google.com/maps?saddr={$current_user_address|escape:'url'}&daddr={$address|escape:'url'}">{$mod_strings.LBL_MAP_GET_DIRECTIONS}</a>
 </div>

--- a/SugarModules/modules/jjwg_Maps/tpls/InfoWindow.tpl
+++ b/SugarModules/modules/jjwg_Maps/tpls/InfoWindow.tpl
@@ -1,7 +1,7 @@
 
 <div class="marker"><b>{$address}</b> 
 <br /><br />
-<a target="_blank" href="http://maps.google.com/maps?q={$address|escape:'url'}">{$mod_strings.LBL_MAP_GOOGLE_MAPS_VIEW}</a>&nbsp;
-<a target="_blank" href="http://maps.google.com/maps?saddr={$current_user_address|escape:'url'}&daddr={$address|escape:'url'}">{$mod_strings.LBL_MAP_GET_DIRECTIONS}</a>
+<a target="_blank" href="https://maps.google.com/maps?q={$address|escape:'url'}">{$mod_strings.LBL_MAP_GOOGLE_MAPS_VIEW}</a>&nbsp;
+<a target="_blank" href="https://maps.google.com/maps?saddr={$current_user_address|escape:'url'}&daddr={$address|escape:'url'}">{$mod_strings.LBL_MAP_GET_DIRECTIONS}</a>
 </div>
 

--- a/SugarModules/modules/jjwg_Maps/tpls/LeadsInfoWindow.tpl
+++ b/SugarModules/modules/jjwg_Maps/tpls/LeadsInfoWindow.tpl
@@ -5,6 +5,6 @@ href="index.php?module={$module_type}&action=DetailView&record={$fields.id}">{$f
 <br />{$address}<br />
 <i>{$mod_strings.LBL_MAP_ASSIGNED_TO} {$fields.assigned_user_name}</i>
 <br /><br />
-<a target="_blank" href="http://maps.google.com/maps?q={$address|escape:'url'}">{$mod_strings.LBL_MAP_GOOGLE_MAPS_VIEW}</a>&nbsp;
-<a target="_blank" href="http://maps.google.com/maps?saddr={$current_user_address|escape:'url'}&daddr={$address|escape:'url'}">{$mod_strings.LBL_MAP_GET_DIRECTIONS}</a>
+<a target="_blank" href="https://maps.google.com/maps?q={$address|escape:'url'}">{$mod_strings.LBL_MAP_GOOGLE_MAPS_VIEW}</a>&nbsp;
+<a target="_blank" href="https://maps.google.com/maps?saddr={$current_user_address|escape:'url'}&daddr={$address|escape:'url'}">{$mod_strings.LBL_MAP_GET_DIRECTIONS}</a>
 </div>

--- a/SugarModules/modules/jjwg_Maps/tpls/MeetingsInfoWindow.tpl
+++ b/SugarModules/modules/jjwg_Maps/tpls/MeetingsInfoWindow.tpl
@@ -10,6 +10,6 @@ href="index.php?module={$module_type}&action=DetailView&record={$fields.id}">{$f
 {$address}<br />
 <i>{$mod_strings.LBL_MAP_ASSIGNED_TO} {$fields.assigned_user_name}</i>
 <br /><br />
-<a target="_blank" href="http://maps.google.com/maps?q={$address|escape:'url'}">{$mod_strings.LBL_MAP_GOOGLE_MAPS_VIEW}</a>&nbsp;
-<a target="_blank" href="http://maps.google.com/maps?saddr={$current_user_address|escape:'url'}&daddr={$address|escape:'url'}">{$mod_strings.LBL_MAP_GET_DIRECTIONS}</a>
+<a target="_blank" href="https://maps.google.com/maps?q={$address|escape:'url'}">{$mod_strings.LBL_MAP_GOOGLE_MAPS_VIEW}</a>&nbsp;
+<a target="_blank" href="https://maps.google.com/maps?saddr={$current_user_address|escape:'url'}&daddr={$address|escape:'url'}">{$mod_strings.LBL_MAP_GET_DIRECTIONS}</a>
 </div>

--- a/SugarModules/modules/jjwg_Maps/tpls/OpportunitiesInfoWindow.tpl
+++ b/SugarModules/modules/jjwg_Maps/tpls/OpportunitiesInfoWindow.tpl
@@ -7,6 +7,6 @@ href="index.php?module=Accounts&action=DetailView&record={$fields.account_id}">{
 <br />{$address}<br />
 <i>{$mod_strings.LBL_MAP_ASSIGNED_TO} {$fields.assigned_user_name}</i>
 <br /><br />
-<a target="_blank" href="http://maps.google.com/maps?q={$address|escape:'url'}">{$mod_strings.LBL_MAP_GOOGLE_MAPS_VIEW}</a>&nbsp;
-<a target="_blank" href="http://maps.google.com/maps?saddr={$current_user_address|escape:'url'}&daddr={$address|escape:'url'}">{$mod_strings.LBL_MAP_GET_DIRECTIONS}</a>
+<a target="_blank" href="https://maps.google.com/maps?q={$address|escape:'url'}">{$mod_strings.LBL_MAP_GOOGLE_MAPS_VIEW}</a>&nbsp;
+<a target="_blank" href="https://maps.google.com/maps?saddr={$current_user_address|escape:'url'}&daddr={$address|escape:'url'}">{$mod_strings.LBL_MAP_GET_DIRECTIONS}</a>
 </div>

--- a/SugarModules/modules/jjwg_Maps/tpls/ProjectInfoWindow.tpl
+++ b/SugarModules/modules/jjwg_Maps/tpls/ProjectInfoWindow.tpl
@@ -5,6 +5,6 @@ href="index.php?module={$module_type}&action=DetailView&record={$fields.id}">{$f
 <br />{$address}<br />
 <i>{$mod_strings.LBL_MAP_ASSIGNED_TO} {$fields.assigned_user_name}</i>
 <br /><br />
-<a target="_blank" href="http://maps.google.com/maps?q={$address|escape:'url'}">{$mod_strings.LBL_MAP_GOOGLE_MAPS_VIEW}</a>&nbsp;
-<a target="_blank" href="http://maps.google.com/maps?saddr={$current_user_address|escape:'url'}&daddr={$address|escape:'url'}">{$mod_strings.LBL_MAP_GET_DIRECTIONS}</a>
+<a target="_blank" href="https://maps.google.com/maps?q={$address|escape:'url'}">{$mod_strings.LBL_MAP_GOOGLE_MAPS_VIEW}</a>&nbsp;
+<a target="_blank" href="https://maps.google.com/maps?saddr={$current_user_address|escape:'url'}&daddr={$address|escape:'url'}">{$mod_strings.LBL_MAP_GET_DIRECTIONS}</a>
 </div>

--- a/SugarModules/modules/jjwg_Maps/tpls/ProspectsInfoWindow.tpl
+++ b/SugarModules/modules/jjwg_Maps/tpls/ProspectsInfoWindow.tpl
@@ -7,6 +7,6 @@ href="index.php?module={$module_type}&action=DetailView&record={$fields.id}">{$f
 <br />{$address}<br />
 <i>{$mod_strings.LBL_MAP_ASSIGNED_TO} {$fields.assigned_user_name}</i>
 <br /><br />
-<a target="_blank" href="http://maps.google.com/maps?q={$address|escape:'url'}">{$mod_strings.LBL_MAP_GOOGLE_MAPS_VIEW}</a>&nbsp;
-<a target="_blank" href="http://maps.google.com/maps?saddr={$current_user_address|escape:'url'}&daddr={$address|escape:'url'}">{$mod_strings.LBL_MAP_GET_DIRECTIONS}</a>
+<a target="_blank" href="https://maps.google.com/maps?q={$address|escape:'url'}">{$mod_strings.LBL_MAP_GOOGLE_MAPS_VIEW}</a>&nbsp;
+<a target="_blank" href="https://maps.google.com/maps?saddr={$current_user_address|escape:'url'}&daddr={$address|escape:'url'}">{$mod_strings.LBL_MAP_GET_DIRECTIONS}</a>
 </div>

--- a/SugarModules/modules/jjwg_Maps/tpls/UsersInfoWindow.tpl
+++ b/SugarModules/modules/jjwg_Maps/tpls/UsersInfoWindow.tpl
@@ -4,6 +4,6 @@
 href="index.php?module={$module_type}&action=DetailView&record={$fields.id}">{$fields.first_name} {$fields.last_name}</a></b> 
 <br />{$address}
 <br /><br />
-<a target="_blank" href="http://maps.google.com/maps?q={$address|escape:'url'}">{$mod_strings.LBL_MAP_GOOGLE_MAPS_VIEW}</a>&nbsp;
-<a target="_blank" href="http://maps.google.com/maps?saddr={$current_user_address|escape:'url'}&daddr={$address|escape:'url'}">{$mod_strings.LBL_MAP_GET_DIRECTIONS}</a>
+<a target="_blank" href="https://maps.google.com/maps?q={$address|escape:'url'}">{$mod_strings.LBL_MAP_GOOGLE_MAPS_VIEW}</a>&nbsp;
+<a target="_blank" href="https://maps.google.com/maps?saddr={$current_user_address|escape:'url'}&daddr={$address|escape:'url'}">{$mod_strings.LBL_MAP_GET_DIRECTIONS}</a>
 </div>

--- a/SugarModules/modules/jjwg_Maps/views/view.map_markers.php
+++ b/SugarModules/modules/jjwg_Maps/views/view.map_markers.php
@@ -178,7 +178,8 @@ var markerClusterer = null;
 var markerClustererToggle = null;
 var clusterControlDiv = null;
 // Clusterer Images - Protocol Independent
-MarkerClusterer.IMAGE_PATH = "//google-maps-utility-library-v3.googlecode.com/svn/trunk/markerclustererplus/images/m";
+//MarkerClusterer.IMAGE_PATH = "//google-maps-utility-library-v3.googlecode.com/svn/trunk/markerclustererplus/images/m";
+MarkerClusterer.IMAGE_PATH = "https://raw.githubusercontent.com/googlemaps/js-marker-clusterer/gh-pages/images/m";
 
 // Drawing Controls
 var drawingManager = null;


### PR DESCRIPTION
http links were leaking CRM system address information over http, before google was redirecting to https.  Better go directly to https and not expose CRM system address information for anyone to steal.
Also the link to googlecode was broken, link is now updated to the working link to the new github repo of the google maps javascript api v3.
